### PR TITLE
storm-yarn commands expanded for cluster managment

### DIFF
--- a/bin/read-link
+++ b/bin/read-link
@@ -14,12 +14,9 @@
 #  limitations under the License. See accompanying LICENSE file.
 #
 
-TARGET_FILE=$1
+cd `dirname $1`
+TARGET_FILE=`basename $1`
 
-cd `dirname $TARGET_FILE`
-TARGET_FILE=`basename $TARGET_FILE`
-
-# Iterate down a (possible) chain of symlinks
 while [ -L "$TARGET_FILE" ]
 do
     TARGET_FILE=`readlink $TARGET_FILE`
@@ -27,8 +24,4 @@ do
     TARGET_FILE=`basename $TARGET_FILE`
 done
 
-# Compute the canonicalized name by finding the physical path 
-# for the directory we're in and appending the target file.
-PHYS_DIR=`pwd -P`
-RESULT=$PHYS_DIR/$TARGET_FILE
-echo $RESULT
+echo "$(pwd -P)/$TARGET_FILE"


### PR DESCRIPTION
storm-yarn has expanded to support the following commands:
1. launch MyStormYARN.yaml --appname MyAppName --queue YarnRMQueueName  ... launch a storm cluster per storm-yran configuration, and return an YARN App ID. 
2. setStormConfig MyStomrYARN.yaml --appId MyAppID ... update storm configuration of a previously launched AppID
3. getStormConfig MyStomrYARN.yaml --appId MyAppID ... retrieve the Storm-Yarn configuration of a previously launched AppID
4. addSupervisors  MyStomrYARN.yaml  --appId MyAppID --supversiors NumSupervisors ... add some supervisors
5. startNimbus  MyStomrYARN.yaml --appId MyAppID ... start Storm nimbus server
6. stopNimbus  MyStomrYARN.yaml --appId MyAppID ... stop Storm nimbus server
7. startUI  MyStomrYARN.yaml --appId MyAppID ... start Storm UI server
8. stopUI  MyStomrYARN.yaml --appId MyAppID ... stop Storm UI server
9. startSupervisors  MyStomrYARN.yaml --appId MyAppID... start Storm supervisors
10. stopSupervisors  MyStomrYARN.yaml --appId MyAppID... stop Storm supervisors

All these commands support the following option
- --output ... outputfile for result data (default: stdout)

We have introduced a new environment for YARN configuration dir:
- STORM_YARN_CONF_DIR ... This directory will be examined first for YARN configuration resources (ex. yarn-site.xml)

Integration test program added for verification.

MacOS is now supported
