### PR TITLE
when supervisor completed not request new yarn containers

### DIFF
--- a/src/main/java/com/yahoo/storm/yarn/MasterServer.java
+++ b/src/main/java/com/yahoo/storm/yarn/MasterServer.java
@@ -95,7 +95,7 @@ public class MasterServer extends ThriftServer {
               
               if (completedContainers.size() > 0 && client.supervisorsAreToRun()) {
                 LOG.debug("HB: Containers completed (" + completedContainers.size() + "), so releasing them.");
-                client.startAllSupervisors();
+                client.addSupervisors(completedContainers.size());
               }
             
             }


### PR DESCRIPTION
When supervisor completed, MasterServer not request new containers because when call startAllSupervisors, numSupervisors always be 0.
